### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/dialogtech.template
+++ b/templates/dialogtech.template
@@ -83,7 +83,7 @@ Resources:
       Code:
         S3Bucket: aws-quickstart
         S3Key: connect-integration-dialogtech/functions/packages/dialogtech-integration-test/dialogtech-integration-test.zip
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: '10'
   IntegrationTest:
     Type: Custom::IntegrationTest
@@ -105,7 +105,7 @@ Resources:
       Code:
         S3Bucket: aws-quickstart
         S3Key: connect-integration-dialogtech/functions/packages/dialogtech-integration/dialogtech-integration.zip
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: '10'
       Environment:
         Variables:


### PR DESCRIPTION
CloudFormation templates in connect-integration-dialogtech have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.